### PR TITLE
Removed two fields from ipcc yaml generator

### DIFF
--- a/tools/ipcc_yaml_file_generator/index.html
+++ b/tools/ipcc_yaml_file_generator/index.html
@@ -58,24 +58,6 @@ CSS -->
     </div>
      <textarea id="chapter_number" class="form-control mb-2" style="min-width: 100%" rows="1"></textarea>
 
-    <div id="caption_title_help" class="alert alert-primary tog">
-        <h4>Caption Title <i class="fas fa-info-circle"></i></h4>
-        <div>
-            Use the figure title from the assessment report draft provided by the TSU
-        </div>
-    </div>
-     <textarea id="caption_title" class="form-control mb-2" style="min-width: 100%" rows="4"></textarea>
-
-    <div id="caption_text_help" class="alert alert-primary tog">
-        <h4>Caption Text <i class="fas fa-info-circle"></i></h4>
-        <div>
-            Use the caption text from the assessment report provided by the TSU 
-        </div>
-    </div>
-    <textarea id="caption_text" class="form-control mb-2" style="min-width: 100%" rows="20">
-
-    </textarea>
-
     <div id="authors_help" class="alert alert-primary tog">
         <h4>Authors <i class="fas fa-info-circle"></i></h4>
         <div>

--- a/tools/ipcc_yaml_file_generator/labeler.js
+++ b/tools/ipcc_yaml_file_generator/labeler.js
@@ -9,12 +9,10 @@ function make_download() {
     var chap_num = $('#chapter_number').val();
     var draft_num = "1st" //make a function to change this!
     var today = current_date();
-    
-    var cap_title = $('#caption_title').val();
-    var cap_text = $('#caption_text').val();
+
     var title = `Data for Figure ${fig_num} from Chapter ${chap_num} of the ${draft_num} draft of the Working Group I Contribution to the IPCC Seventh Assessment Report (v${today})`;
     var description = `This dataset contains the final data for Figure ${fig_num} from Chapter ${chap_num} of the Working Group I (WGI) Contribution to the Intergovernmental Panel on Climate Change (IPCC) Seventh Assessment Report (AR7). Additional information, including how to cite this figure dataset, is provided in the README.txt alongside the data. 
-    Figure ${fig_num} caption: ${cap_title} ${cap_text}
+    Figure ${fig_num} caption: [ADD]
     Links to the figure, report chapter and supplementary material are provided in the Details/Docs section of this catalogue record. Code to reproduce the figure which is hosted on GitHub is also linked, and described under the Process tab below.`;
 
     var authors = $('#authors input');


### PR DESCRIPTION
Removed the two fields asking for caption title and text from the yaml file generator form 